### PR TITLE
Revert "Move logger interface from usecase to interfaces"

### DIFF
--- a/app/infrastructure/router.go
+++ b/app/infrastructure/router.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/bmf-san/gobel-api/app/interfaces"
 	"github.com/bmf-san/gobel-api/app/middleware"
+	"github.com/bmf-san/gobel-api/app/usecase"
 	"github.com/bmf-san/goblin"
 	"github.com/go-redis/redis/v7"
 )
 
 // Route sets the routing.
-func Route(connMySQL *sql.DB, connRedis *redis.Client, l interfaces.Logger) *goblin.Router {
+func Route(connMySQL *sql.DB, connRedis *redis.Client, l usecase.Logger) *goblin.Router {
 	ar := interfaces.AdminRepository{
 		ConnMySQL: connMySQL,
 		ConnRedis: connRedis,

--- a/app/interfaces/auth_controller.go
+++ b/app/interfaces/auth_controller.go
@@ -14,7 +14,7 @@ type AuthController struct {
 }
 
 // NewAuthController creates an AuthController.
-func NewAuthController(connMySQL *sql.DB, connRedis *redis.Client, logger Logger) *AuthController {
+func NewAuthController(connMySQL *sql.DB, connRedis *redis.Client, logger usecase.Logger) *AuthController {
 	return &AuthController{
 		AuthInteractor: usecase.AuthInteractor{
 			AdminRepository: &AdminRepository{

--- a/app/interfaces/category_controller.go
+++ b/app/interfaces/category_controller.go
@@ -10,11 +10,11 @@ import (
 // A CategoryController is a controller for a comment.
 type CategoryController struct {
 	CategoryInteractor usecase.CategoryInteractor
-	Logger             Logger
+	Logger             usecase.Logger
 }
 
 // NewCategoryController creates a CategoryController.
-func NewCategoryController(connMySQL *sql.DB, logger Logger) *CategoryController {
+func NewCategoryController(connMySQL *sql.DB, logger usecase.Logger) *CategoryController {
 	return &CategoryController{
 		CategoryInteractor: usecase.CategoryInteractor{
 			CategoryRepository: &CategoryRepository{

--- a/app/interfaces/comment_controller.go
+++ b/app/interfaces/comment_controller.go
@@ -10,11 +10,11 @@ import (
 // A CommentController is a controller for a comment.
 type CommentController struct {
 	CommentInteractor usecase.CommentInteractor
-	Logger            Logger
+	Logger            usecase.Logger
 }
 
 // NewCommentController creates a CommentController.
-func NewCommentController(connMySQL *sql.DB, logger Logger) *CommentController {
+func NewCommentController(connMySQL *sql.DB, logger usecase.Logger) *CommentController {
 	return &CommentController{
 		CommentInteractor: usecase.CommentInteractor{
 			CommentRepository: &CommentRepository{

--- a/app/interfaces/post_controller.go
+++ b/app/interfaces/post_controller.go
@@ -11,11 +11,11 @@ import (
 // A PostController is a controller for a post.
 type PostController struct {
 	PostInteractor usecase.PostInteractor
-	Logger         Logger
+	Logger         usecase.Logger
 }
 
 // NewPostController creates a PostController.
-func NewPostController(connMySQL *sql.DB, connRedis *redis.Client, logger Logger) *PostController {
+func NewPostController(connMySQL *sql.DB, connRedis *redis.Client, logger usecase.Logger) *PostController {
 	return &PostController{
 		PostInteractor: usecase.PostInteractor{
 			AdminRepository: &AdminRepository{

--- a/app/interfaces/tag_controller.go
+++ b/app/interfaces/tag_controller.go
@@ -10,11 +10,11 @@ import (
 // A TagController is a controller for a post.
 type TagController struct {
 	TagInteractor usecase.TagInteractor
-	Logger        Logger
+	Logger        usecase.Logger
 }
 
 // NewTagController creates a TagController.
-func NewTagController(connMySQL *sql.DB, logger Logger) *TagController {
+func NewTagController(connMySQL *sql.DB, logger usecase.Logger) *TagController {
 	return &TagController{
 		TagInteractor: usecase.TagInteractor{
 			TagRepository: &TagRepository{

--- a/app/middleware/middleware.go
+++ b/app/middleware/middleware.go
@@ -7,16 +7,17 @@ import (
 
 	"github.com/bmf-san/gobel-api/app/domain"
 	"github.com/bmf-san/gobel-api/app/interfaces"
+	"github.com/bmf-san/gobel-api/app/usecase"
 )
 
 // Middleware represents the plural of middelware.
 type Middleware struct {
-	logger          interfaces.Logger
+	logger          usecase.Logger
 	adminRepository interfaces.AdminRepository
 	jwtRepository   interfaces.JWTRepository
 }
 
-func NewMiddleware(l interfaces.Logger, ar interfaces.AdminRepository, jr interfaces.JWTRepository) *Middleware {
+func NewMiddleware(l usecase.Logger, ar interfaces.AdminRepository, jr interfaces.JWTRepository) *Middleware {
 	return &Middleware{
 		logger:          l,
 		adminRepository: ar,

--- a/app/usecase/logger.go
+++ b/app/usecase/logger.go
@@ -1,4 +1,4 @@
-package interfaces
+package usecase
 
 // A Logger represents a logger.
 type Logger interface {


### PR DESCRIPTION
Reverts bmf-san/gobel-api#67

I remembered that the logger interface was defined in the usercase layer to reverse the dependencies.