### PR TITLE
Fix Dockerfile for local

### DIFF
--- a/app/Dockerfile.local
+++ b/app/Dockerfile.local
@@ -5,7 +5,7 @@ WORKDIR /go/gobel-api/app
 RUN apk update && \
     apk upgrade && \
     apk add --no-cache libc-dev gcc git openssh openssl bash && \
-    go get -u github.com/cosmtrek/air && \
-    go get -u golang.org/x/lint/golint
+    go install github.com/cosmtrek/air@latest && \
+    go install golang.org/x/lint/golint@latest
 
 CMD air -c .air.toml


### PR DESCRIPTION
# Overview
Use `go install` instead of using `go get

# Changes
- Dockerfile.locak

# Impact range
Local environment

# Operational Requirements
N/A

# Related Issue
N/A

# Supplement
N/A
