### PR TITLE
Removed the ON UPDATE clause of created_at

### DIFF
--- a/mysql/initdb.d/1_schema.sql
+++ b/mysql/initdb.d/1_schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE `admins` (
   `name` varchar(255) NOT NULL UNIQUE,
   `email` varchar(255) NOT NULL UNIQUE,
   `password` varchar(255) NOT NULL,
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
@@ -12,7 +12,7 @@ DROP TABLE IF EXISTS `categories`;
 CREATE TABLE `categories` (
   `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `name` varchar(255) NOT NULL UNIQUE,
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
@@ -25,7 +25,7 @@ CREATE TABLE `posts` (
   `md_body` longtext DEFAULT NULL,
   `html_body` longtext DEFAULT NULL,
   `status` varchar(255) DEFAULT "draft",
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (admin_id) REFERENCES admins(id),
   FOREIGN KEY (category_id) REFERENCES categories(id)
@@ -37,7 +37,7 @@ CREATE TABLE `comments` (
   `post_id` int(11) UNSIGNED NOT NULL,
   `body` longtext NOT NULL,
   `status` varchar(255) DEFAULT "pending",
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (post_id) REFERENCES posts(id)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
@@ -46,7 +46,7 @@ DROP TABLE IF EXISTS `tags`;
 CREATE TABLE `tags` (
   `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `name` varchar(255) NOT NULL UNIQUE,
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
@@ -55,7 +55,7 @@ CREATE TABLE `tag_post` (
   `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `tag_id` int(11) UNSIGNED NOT NULL,
   `post_id` int(11) UNSIGNED NOT NULL,
-  `created_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (tag_id) REFERENCES tags(id),
   FOREIGN KEY (post_id) REFERENCES posts(id)


### PR DESCRIPTION
# Overview
created_at was updated every time there was an update. 😇 😇 😇 

# Changes
Scema changed.

# Impact range
ALL tables.

# Operational Requirements
```sql
ALTER TABLE table_name MODIFY COLUMN created_at datetime DEFAULT CURRENT_TIMESTAMP;
```

# Related Issue
N/A

# Supplement
N/A
